### PR TITLE
Fix RCON connection state and error handling

### DIFF
--- a/server/modules/rcon/rcon.service.ts
+++ b/server/modules/rcon/rcon.service.ts
@@ -17,6 +17,7 @@ type BattleyeConnection = any;
 export class RconService {
   private static socket: BattleyeSocket | null = null;
   private static connection: BattleyeConnection | null = null;
+  private static connected = false;
   private static lastMessages: string[] = [];
 
   private readonly db = getPrisma();
@@ -25,7 +26,7 @@ export class RconService {
 
   status() {
     return {
-      connected: !!RconService.connection,
+      connected: RconService.connected,
       lastMessages: RconService.lastMessages.slice(-200),
     };
   }
@@ -39,7 +40,12 @@ export class RconService {
    * - Never crashes the whole app; errors are wrapped as AppError with stable error codes.
    */
   async connect() {
-    if (RconService.connection) return { ok: true, alreadyConnected: true, ...this.status() };
+    if (RconService.connection && RconService.connected) {
+      return { ok: true, alreadyConnected: true, ...this.status() };
+    }
+    if (RconService.connection && !RconService.connected) {
+      await this.disconnect();
+    }
 
     const s = await this.settings.get();
     const ip = (s.rconHost || "127.0.0.1").trim();
@@ -94,14 +100,17 @@ export class RconService {
     });
 
     conn.on("connected", () => {
+      RconService.connected = true;
       pushMessage("connected");
       this.log.info("RCON connected", { code: "RCON_CONNECTED", context: { ip, port } });
     });
     conn.on("disconnected", (reason: any) => {
+      RconService.connected = false;
       pushMessage(`disconnected: ${safeJson(reason)}`);
       this.log.warn("RCON disconnected", { code: "RCON_DISCONNECTED", context: { reason } });
     });
     conn.on("error", (err: any) => {
+      RconService.connected = false;
       pushMessage(`connection error: ${String(err?.message ?? err)}`);
       this.log.warn("RCON connection error", {
         code: ErrorCodes.RCON_CONNECTION_FAILED,
@@ -111,6 +120,20 @@ export class RconService {
 
     RconService.socket = socket;
     RconService.connection = conn;
+    RconService.connected = false;
+
+    try {
+      await waitForConnection(conn);
+    } catch (err) {
+      await this.disconnect();
+      throw new AppError({
+        code: ErrorCodes.RCON_CONNECTION_FAILED,
+        status: 500,
+        message: "RCON connection failed",
+        cause: err,
+        context: { ip, port },
+      });
+    }
 
     return { ok: true, ...this.status() };
   }
@@ -124,6 +147,7 @@ export class RconService {
     const conn = RconService.connection;
     RconService.connection = null;
     RconService.socket = null;
+    RconService.connected = false;
 
     try {
       conn?.disconnect?.();
@@ -142,10 +166,10 @@ export class RconService {
    * Sends a command. If not connected, tries to connect first.
    */
   async command(cmd: string) {
-    if (!RconService.connection) {
+    if (!RconService.connection || !RconService.connected) {
       await this.connect();
     }
-    if (!RconService.connection) {
+    if (!RconService.connection || !RconService.connected) {
       throw new AppError({
         code: ErrorCodes.RCON_NOT_CONNECTED,
         status: 400,
@@ -222,4 +246,46 @@ async function loadBattleye() {
       cause: err,
     });
   }
+}
+
+async function waitForConnection(conn: BattleyeConnection, timeoutMs = 10000) {
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error("RCON connection timed out"));
+    }, timeoutMs);
+
+    const onConnected = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const onError = (err: any) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err ?? new Error("RCON connection error"));
+    };
+    const onDisconnected = (reason: any) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(`RCON disconnected: ${safeJson(reason)}`));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      conn.off?.("connected", onConnected);
+      conn.off?.("error", onError);
+      conn.off?.("disconnected", onDisconnected);
+    };
+
+    conn.once?.("connected", onConnected);
+    conn.once?.("error", onError);
+    conn.once?.("disconnected", onDisconnected);
+  });
 }


### PR DESCRIPTION
### Motivation
- RCON client reported connected state prematurely and commands could be attempted before an actual connection was established.
- The goal is to make `connect` return only after a verified connection, and to ensure connection state is tracked and cleared on errors or disconnects.

### Description
- Added a `connected` static flag to `server/modules/rcon/rcon.service.ts` and updated `status()` to use it instead of inferring from the socket object.
- Make `connect()` disconnect any stale connection, set up event handlers to update `connected`, and wait for a successful `connected` event (`waitForConnection`) with timeout before returning.
- Set `connected = false` on `disconnected`/`error` and during `disconnect()`, and hardened `command()` to require `connected` before sending.
- Introduced `waitForConnection()` helper to race `connected`/`error`/`disconnected` events with a timeout and to surface a clear `RCON_CONNECTION_FAILED` error on failure.

### Testing
- No automated tests were run for this change.
- Manual verification is recommended: call `/api/rcon/connect`, ensure it only returns after an actual connection or returns a clear error on timeout, then exercise `/api/rcon/command` and `/api/rcon/disconnect`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d2aa0b41c832fab04e8bd6e8d641a)