### PR TITLE
Skip RCON shutdown when disconnected and wait for graceful exit before killing server

### DIFF
--- a/server/modules/server-control/serverControl.service.ts
+++ b/server/modules/server-control/serverControl.service.ts
@@ -163,19 +163,43 @@ export class ServerControlService {
   /**
    * Stops the process.
    *
-   * NOTE: This is a simple kill for now.
-   * Future improvement:
-   * - send "#shutdown" via RCON (BattlEye)
-   * - wait N seconds
-   * - then kill if needed
+   * NOTE: We attempt a graceful RCON shutdown if already connected,
+   * then fall back to a hard kill after a short wait.
    */
   async stop() {
     const proc = ServerControlService.proc;
     if (!proc) return { ok: true, alreadyStopped: true };
 
     try {
+      let requestedShutdown = false;
+
+      try {
+        if (this.rcon.status().connected) {
+          const res = await this.rcon.command("#shutdown");
+          requestedShutdown = true;
+          this.log.info("RCON shutdown command sent", {
+            code: "RCON_SHUTDOWN_SENT",
+            context: { response: res?.response ?? res },
+          });
+        } else {
+          this.log.info("RCON shutdown skipped (not connected)", {
+            code: "RCON_SHUTDOWN_SKIPPED",
+          });
+        }
+      } catch (err) {
+        this.log.warn("RCON shutdown command failed", {
+          code: ErrorCodes.RCON_COMMAND_FAILED,
+          context: { message: (err as any)?.message ?? String(err) },
+        });
+      }
+
+      if (requestedShutdown) {
+        const graceful = await waitForExit(proc, 10000);
+        if (graceful) return { ok: true, graceful: true };
+      }
+
       proc.kill();
-      return { ok: true };
+      return { ok: true, graceful: false };
     } catch (err) {
       throw new AppError({
         code: ErrorCodes.SERVER_PROCESS_STOP_FAILED,
@@ -196,6 +220,26 @@ export class ServerControlService {
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForExit(proc: ChildProcessWithoutNullStreams, timeoutMs: number) {
+  return new Promise<boolean>((resolve) => {
+    let resolved = false;
+    const onClose = () => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      proc.off("close", onClose);
+      resolve(false);
+    }, timeoutMs);
+
+    proc.once("close", onClose);
+  });
 }
 
 /**


### PR DESCRIPTION
### Motivation

- Avoid attempting an RCON `#shutdown` when the management panel is not connected so we don't trigger failing remote commands. 
- Prefer a graceful server stop when possible by waiting briefly for process exit before falling back to a hard kill.

### Description

- Update `stop()` to check `this.rcon.status().connected` and only call `this.rcon.command("#shutdown")` when connected, otherwise log `RCON_SHUTDOWN_SKIPPED`.
- Preserve logging for successful sends (`RCON_SHUTDOWN_SENT`) and failures using `ErrorCodes.RCON_COMMAND_FAILED` and handle exceptions from the RCON call.
- Add `waitForExit(proc, timeoutMs)` helper that waits for the process `close` event up to a timeout and returns a boolean indicating graceful exit. 
- If a graceful exit is observed `stop()` returns `{ ok: true, graceful: true }`, otherwise it falls back to `proc.kill()` and returns `{ ok: true, graceful: false }`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e3d18292c832f9ee27fe079d17dbd)