### PR TITLE
Add Linux install/start scripts and cross-platform defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Hedef: Omega Manager / CFTools Cloud benzeri bir deneyim sunmak; **SteamCMD**, *
 
 ## Mevcut sürümde (v0.1) neler var?
 
-- **Kurulum / çalıştırma BAT dosyaları** (loglu)
-  - `scripts/windows/install.bat`
-  - `scripts/windows/start.bat`
+- **Kurulum / çalıştırma scriptleri** (loglu)
+  - Windows: `scripts/windows/install.bat`, `scripts/windows/start.bat`
+  - Linux/Codex: `scripts/linux/install.sh`, `scripts/linux/start.sh`
 - **SQLite lokal DB** (Prisma)
   - Ayarlar (DB’de), mod listesi, hata logları
 - **Settings ekranı**
@@ -23,7 +23,7 @@ Hedef: Omega Manager / CFTools Cloud benzeri bir deneyim sunmak; **SteamCMD**, *
   - Enable/Disable ile server start argümanına otomatik dahil etme
 - **Server kontrol**
   - Start / Stop / Restart
-  - Enable modlar için server klasörüne **Junction link (mklink /J)** oluşturma (Windows)
+  - Enable modlar için server klasörüne **Junction link (mklink /J)** (Windows) veya **symlink** (Linux) oluşturma
 - **BattlEye config editor**
   - `BEServer_x64.cfg` parse + raw edit
 - **RCON Console**
@@ -56,6 +56,35 @@ Bu script:
    `http://localhost:3000`
 
 > Hem `install.bat` hem `start.bat` çıktıları `./data/logs/...` altına loglanır.
+
+## Kurulum (Linux / Codex)
+
+1. ZIP’i bir klasöre çıkar.
+2. Terminal aç ve aşağıdaki scriptleri çalıştır:
+
+   ```bash
+   chmod +x scripts/linux/install.sh scripts/linux/start.sh
+   scripts/linux/install.sh
+   ```
+
+Bu script:
+- Node.js 22.x mevcut mu kontrol eder
+- `pnpm install` (yoksa `npm install`)
+- `.env.example` -> `.env` kopyalar
+- DB’yi başlatır (`prisma db push`)
+- Build alır
+
+3. Ardından paneli başlat:
+
+   ```bash
+   scripts/linux/start.sh
+   ```
+
+4. Tarayıcıdan aç:
+
+   `http://localhost:3000`
+
+> Hem `install.sh` hem `start.sh` çıktıları `./data/logs/...` altına loglanır.
 
 ## GitHub'a yukleme (opsiyonel)
 
@@ -97,6 +126,9 @@ dayz-web-panel/
   scripts/windows/
     install.bat
     start.bat
+  scripts/linux/
+    install.sh
+    start.sh
 ```
 
 ## Mimari

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -92,7 +92,7 @@ export default function Settings() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Paths (Windows)</CardTitle>
+          <CardTitle>Paths (Windows/Linux)</CardTitle>
         </CardHeader>
         <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Field label="SteamCMD Path" value={form.steamcmdPath} onChange={(v) => update("steamcmdPath", v)} />

--- a/docs/README_TR.md
+++ b/docs/README_TR.md
@@ -1,20 +1,26 @@
-# DayZ Web Panel — Windows 11 Kurulum Rehberi (TR)
+# DayZ Web Panel — Kurulum Rehberi (TR)
 
-Bu dokuman, Windows 11 uzerinde panelin kurulumu, baslatilmasi ve sorun giderme adimlarini icerir.
+Bu dokuman, Windows 11 ve Linux uzerinde panelin kurulumu, baslatilmasi ve sorun giderme adimlarini icerir.
 
 ## 1) Onkosullar
-- Windows 11
+- Windows 11 veya Linux
 - Internet erisimi (SteamCMD, npm paketleri icin)
 - Diskte yeterli alan (DayZ server + modlar icin)
 
 ## 2) Varsayilan yollar
 UI tarafindan degistirilebilir, ancak varsayilanlar:
-- DayZ server: `E:\steamcmd\steamapps\common\DayZServer`
-- SteamCMD: `E:\steamcmd\steamcmd.exe`
-- BattlEye cfg: `E:\steamcmd\steamapps\common\DayZServer\profiles\BattlEye\BEServer_x64.cfg`
-- BattlEye profiles: `E:\steamcmd\steamapps\common\DayZServer\profiles\BattlEye`
+- Windows:
+  - DayZ server: `E:\steamcmd\steamapps\common\DayZServer`
+  - SteamCMD: `E:\steamcmd\steamcmd.exe`
+  - BattlEye cfg: `E:\steamcmd\steamapps\common\DayZServer\profiles\BattlEye\BEServer_x64.cfg`
+  - BattlEye profiles: `E:\steamcmd\steamapps\common\DayZServer\profiles\BattlEye`
+- Linux:
+  - DayZ server: `/opt/steamcmd/steamapps/common/DayZServer`
+  - SteamCMD: `/opt/steamcmd/steamcmd.sh`
+  - BattlEye cfg: `/opt/steamcmd/steamapps/common/DayZServer/profiles/BattlEye/BEServer_x64.cfg`
+  - BattlEye profiles: `/opt/steamcmd/steamapps/common/DayZServer/profiles/BattlEye`
 
-## 3) Kurulum
+## 3) Kurulum (Windows 11)
 PowerShell ya da CMD uzerinden:
 
 ```bat
@@ -28,7 +34,7 @@ Kurulum asamalari:
 - `npm run build`
 - Log: `data\logs\install-YYYYMMDD-HHMMSS.log`
 
-## 4) Baslatma
+## 4) Baslatma (Windows 11)
 
 ```bat
 scripts\windows\start.bat
@@ -45,7 +51,41 @@ Uygulama acildiginda:
 http://localhost:3000
 ```
 
-## 5) Doctor komutu
+## 5) Kurulum (Linux)
+
+Terminal uzerinden:
+
+```bash
+chmod +x scripts/linux/install.sh scripts/linux/start.sh
+scripts/linux/install.sh
+```
+
+Kurulum asamalari:
+- Node.js 22.x mevcut mu kontrol edilir
+- `pnpm install` (yoksa `npm install`)
+- `.env` yoksa `.env.example` kopyalanir
+- `db:setup`
+- `build`
+- Log: `data/logs/install-YYYYMMDD-HHMMSS.log`
+
+## 6) Baslatma (Linux)
+
+```bash
+scripts/linux/start.sh
+```
+
+Baslatma asamalari:
+- `db:setup`
+- Build yoksa `build`
+- Server baslatilir
+- Log: `data/logs/start-YYYYMMDD-HHMMSS.log`
+
+Uygulama acildiginda:
+```
+http://localhost:3000
+```
+
+## 7) Doctor komutu
 Sistem sagligini hizli kontrol etmek icin:
 
 ```bash
@@ -60,7 +100,7 @@ Kontroller:
 - Settings icinde SteamCMD / DayZ / BattlEye path’leri set mi
 - RCON dependency (battleye) sagligi
 
-## 6) Sorun Giderme (FAQ)
+## 8) Sorun Giderme (FAQ)
 
 ### A) Kurulum sirasinda npm komutlari yarida kesiliyor
 - Windows batch dosyalarinda `npm` komutlari `call npm ...` olarak calismalidir.
@@ -77,4 +117,3 @@ Kontroller:
 
 ### D) Ayar yollarini guncellemek
 UI uzerindeki Settings sayfasindan DayZ/SteamCMD/BattlEye pathlerini girip kaydedin.
-

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f package.json ]]; then
+  echo "ERROR: package.json not found. Please run from the project root." >&2
+  exit 2
+fi
+
+mkdir -p data/logs
+TS="$(date +%Y%m%d-%H%M%S)"
+LOG_FILE="data/logs/install-${TS}.log"
+
+log() {
+  echo "$1" | tee -a "$LOG_FILE"
+}
+
+log "=== DayZ Web Panel Installer (Linux) ==="
+log "Working dir: $ROOT"
+
+if ! command -v node >/dev/null 2>&1; then
+  log "ERROR: Node.js not found. Install Node.js 22.x before running this script."
+  exit 10
+fi
+
+PM=""
+if command -v pnpm >/dev/null 2>&1; then
+  PM="pnpm"
+else
+  if command -v corepack >/dev/null 2>&1; then
+    log "pnpm not found. Enabling corepack + preparing pnpm..."
+    corepack enable >>"$LOG_FILE" 2>&1 || true
+    corepack prepare pnpm@10.14.0 --activate >>"$LOG_FILE" 2>&1 || true
+  fi
+  if command -v pnpm >/dev/null 2>&1; then
+    PM="pnpm"
+  fi
+fi
+
+if [[ -z "$PM" ]]; then
+  PM="npm"
+fi
+
+if [[ "$PM" == "pnpm" ]]; then
+  log "Running pnpm install --frozen-lockfile..."
+  if ! pnpm install --frozen-lockfile >>"$LOG_FILE" 2>&1; then
+    log "WARN: pnpm install failed. Falling back to npm install --include=dev..."
+    PM="npm"
+  fi
+fi
+
+if [[ "$PM" == "npm" ]]; then
+  log "Running npm install --include=dev..."
+  npm install --include=dev >>"$LOG_FILE" 2>&1
+fi
+
+if [[ ! -f .env ]]; then
+  if [[ -f .env.example ]]; then
+    cp .env.example .env
+    log "Created .env from .env.example"
+  else
+    log "ERROR: .env.example missing."
+    exit 13
+  fi
+else
+  log ".env already exists."
+fi
+
+log "Initializing DB (prisma generate + db push)..."
+"$PM" run db:setup >>"$LOG_FILE" 2>&1
+
+log "Building (client + server)..."
+"$PM" run build >>"$LOG_FILE" 2>&1
+
+log "SUCCESS: Install complete."
+log "Next: run scripts/linux/start.sh"

--- a/scripts/linux/start.sh
+++ b/scripts/linux/start.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f package.json ]]; then
+  echo "[FATAL] package.json not found. Root: $ROOT" >&2
+  exit 2
+fi
+
+LOG_DIR="$ROOT/data/logs"
+mkdir -p "$LOG_DIR"
+TS="$(date +%Y%m%d-%H%M%S)"
+LOG_FILE="$LOG_DIR/start-${TS}.log"
+
+log() {
+  echo "$1" | tee -a "$LOG_FILE"
+}
+
+log "=== DayZ Web Panel Start (Linux) ==="
+log "Root: $ROOT"
+
+PM=""
+if command -v pnpm >/dev/null 2>&1; then
+  PM="pnpm"
+else
+  if command -v corepack >/dev/null 2>&1; then
+    corepack enable >>"$LOG_FILE" 2>&1 || true
+    corepack prepare pnpm@10.14.0 --activate >>"$LOG_FILE" 2>&1 || true
+  fi
+  if command -v pnpm >/dev/null 2>&1; then
+    PM="pnpm"
+  else
+    PM="npm"
+  fi
+fi
+
+log "Ensuring Prisma client + DB schema (db:setup)..."
+"$PM" run db:setup >>"$LOG_FILE" 2>&1
+
+if [[ ! -f "$ROOT/dist/server/node-build.mjs" ]]; then
+  log "Build not found. Running build..."
+  "$PM" run build >>"$LOG_FILE" 2>&1
+else
+  log "Build exists. Skipping build."
+fi
+
+log "Starting server..."
+node "$ROOT/dist/server/node-build.mjs" >>"$LOG_FILE" 2>&1
+CODE=$?
+log "Server process exited with code $CODE."
+exit $CODE

--- a/server/modules/mods/mods.service.ts
+++ b/server/modules/mods/mods.service.ts
@@ -67,7 +67,7 @@ export class ModsService {
       throw new AppError({
         code: ErrorCodes.STEAMCMD_NOT_FOUND,
         status: 400,
-        message: "steamcmd.exe not found. Please set SteamCMD path in Settings.",
+        message: "SteamCMD not found. Please set the correct SteamCMD path in Settings.",
         context: { steamcmdPath: s.steamcmdPath },
       });
     }
@@ -176,7 +176,7 @@ async function fetchWorkshopDetails(workshopId: string) {
 function runProcess(command: string, args: string[]) {
   return new Promise<{ exitCode: number; stdout: string }>((resolve) => {
     const child = spawn(command, args, {
-      windowsHide: true,
+      windowsHide: process.platform === "win32",
     });
     let stdout = "";
     child.stdout.on("data", (d) => (stdout += d.toString()));


### PR DESCRIPTION
### Motivation

- Enable running and testing the panel on Linux/Codex while preserving Windows behavior and defaults.
- Make path defaults, SteamCMD handling and mod linking behave correctly on non‑Windows platforms.

### Description

- Add `scripts/linux/install.sh` and `scripts/linux/start.sh` to provide logged install/start flows with `pnpm`/`npm` fallback and `db:setup`/`build` steps. 
- Make settings defaults platform-aware and use POSIX paths on Linux; update `instanceSettingsSchema` defaults in `server/modules/settings/settings.service.ts`.
- Improve DayZ executable detection in `getDayzExecutablePath()` to check appropriate candidate names on Linux and Windows.
- Make server spawn and SteamCMD invocation platform-aware (`windowsHide`), and create mod links as Windows junctions (`mklink /J`) on Windows or POSIX symlinks on Linux in `serverControl.service.ts` and `mods.service.ts`.
- Update UI label in `client/pages/Settings.tsx` and add documentation for Linux/Codex setup in `README.md` and `docs/README_TR.md`.

### Testing

- Ran `pnpm dev` / attempted to start the dev server which failed to start because the Prisma client was not yet available in this environment. 
- Ran `pnpm db:setup` which failed during `prisma generate` due to a Prisma engine checksum download returning `403 Forbidden` in this environment.
- Attempted an automated Playwright navigation to `/settings` which failed because the dev server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e41db9548832fb5e521d90fa39aeb)