### PR TITLE
Refactor Dashboard and Settings into modular components

### DIFF
--- a/client/components/dashboard/ActivityFeedCard.tsx
+++ b/client/components/dashboard/ActivityFeedCard.tsx
@@ -1,0 +1,34 @@
+import type { recentActivity } from "@/components/dashboard/dashboardData";
+
+type ActivityFeedCardProps = {
+  items: typeof recentActivity;
+};
+
+export default function ActivityFeedCard({
+  items,
+}: ActivityFeedCardProps) {
+  return (
+    <div className="bg-card border border-border rounded-lg p-6 h-full">
+      <h3 className="text-xl font-bold text-foreground mb-6">
+        Recent Activity
+      </h3>
+
+      <div className="space-y-4">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="pb-4 border-b border-border last:pb-0 last:border-0"
+          >
+            <p className="text-sm font-medium text-foreground">
+              {item.action}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">{item.player}</p>
+            <p className="text-xs text-muted-foreground/60 mt-2">
+              {item.time}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/components/dashboard/DashboardHeader.tsx
+++ b/client/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,10 @@
+export default function DashboardHeader() {
+  return (
+    <div className="mb-8">
+      <h2 className="text-3xl font-bold text-foreground mb-2">Dashboard</h2>
+      <p className="text-muted-foreground">
+        Welcome to your DayZ server management panel
+      </p>
+    </div>
+  );
+}

--- a/client/components/dashboard/DashboardStatsGrid.tsx
+++ b/client/components/dashboard/DashboardStatsGrid.tsx
@@ -1,0 +1,36 @@
+import { Users, Zap, Clock, Activity } from "lucide-react";
+import StatCard from "@/components/StatCard";
+
+export default function DashboardStatsGrid() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+      <StatCard
+        label="Players Online"
+        value="3/32"
+        icon={<Users className="w-6 h-6" />}
+        trend={{ value: 15, isPositive: true }}
+        color="emerald"
+      />
+      <StatCard
+        label="Server Uptime"
+        value="12d 8h"
+        icon={<Clock className="w-6 h-6" />}
+        color="cyan"
+      />
+      <StatCard
+        label="CPU Usage"
+        value="24%"
+        icon={<Zap className="w-6 h-6" />}
+        trend={{ value: 5, isPositive: true }}
+        color="amber"
+      />
+      <StatCard
+        label="Network"
+        value="145 Mbps"
+        icon={<Activity className="w-6 h-6" />}
+        trend={{ value: 2, isPositive: false }}
+        color="cyan"
+      />
+    </div>
+  );
+}

--- a/client/components/dashboard/OnlinePlayersCard.tsx
+++ b/client/components/dashboard/OnlinePlayersCard.tsx
@@ -1,0 +1,35 @@
+import PlayerCard from "@/components/PlayerCard";
+import type { onlinePlayers } from "@/components/dashboard/dashboardData";
+
+type OnlinePlayersCardProps = {
+  players: typeof onlinePlayers;
+};
+
+export default function OnlinePlayersCard({
+  players,
+}: OnlinePlayersCardProps) {
+  return (
+    <div className="bg-card border border-border rounded-lg p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-bold text-foreground">Online Players</h3>
+        <span className="px-3 py-1 rounded-full bg-primary/20 text-primary text-sm font-semibold">
+          {players.length} Active
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4">
+        {players.map((player) => (
+          <PlayerCard
+            key={player.id}
+            name={player.name}
+            playerId={player.playerId}
+            playtime={player.playtime}
+            status={player.status}
+            kills={player.kills}
+            deaths={player.deaths}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/components/dashboard/ServerControlsCard.tsx
+++ b/client/components/dashboard/ServerControlsCard.tsx
@@ -1,0 +1,23 @@
+export default function ServerControlsCard() {
+  return (
+    <div className="bg-card border border-border rounded-lg p-6">
+      <h3 className="text-lg font-bold text-foreground mb-4">
+        Server Controls
+      </h3>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <button className="btn-primary px-4 py-3 rounded-lg font-semibold transition-all hover:shadow-lg hover:shadow-primary/20">
+          Restart Server
+        </button>
+        <button className="btn-primary px-4 py-3 rounded-lg font-semibold transition-all hover:shadow-lg hover:shadow-primary/20">
+          Save World
+        </button>
+        <button className="btn-secondary px-4 py-3 rounded-lg font-semibold">
+          Broadcast Message
+        </button>
+        <button className="btn-secondary px-4 py-3 rounded-lg font-semibold">
+          View Logs
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/components/dashboard/dashboardData.ts
+++ b/client/components/dashboard/dashboardData.ts
@@ -1,0 +1,56 @@
+export const onlinePlayers = [
+  {
+    id: "1",
+    name: "SurvivalMaster",
+    playerId: "76561198012345678",
+    playtime: "45 hrs",
+    status: "online" as const,
+    kills: 23,
+    deaths: 8,
+  },
+  {
+    id: "2",
+    name: "ZombieSH00TER",
+    playerId: "76561198087654321",
+    playtime: "32 hrs",
+    status: "online" as const,
+    kills: 15,
+    deaths: 12,
+  },
+  {
+    id: "3",
+    name: "DesperateFarmer",
+    playerId: "76561198056789012",
+    playtime: "12 hrs",
+    status: "online" as const,
+    kills: 3,
+    deaths: 5,
+  },
+];
+
+export const recentActivity = [
+  {
+    id: "1",
+    action: "Player joined",
+    player: "SurvivalMaster",
+    time: "5 minutes ago",
+  },
+  {
+    id: "2",
+    action: "Player left",
+    player: "NightOwl",
+    time: "12 minutes ago",
+  },
+  {
+    id: "3",
+    action: "Server restarted",
+    player: "Admin",
+    time: "2 hours ago",
+  },
+  {
+    id: "4",
+    action: "Player banned",
+    player: "RudePlayer",
+    time: "1 day ago",
+  },
+];

--- a/client/components/settings/SettingsCftoolsCard.tsx
+++ b/client/components/settings/SettingsCftoolsCard.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import SettingsField from "@/components/settings/SettingsField";
+import type { SettingsModel } from "@/types/settings";
+import type { UpdateSettings } from "@/components/settings/types";
+
+type SettingsCftoolsCardProps = {
+  form: SettingsModel;
+  onUpdate: UpdateSettings;
+};
+
+export default function SettingsCftoolsCard({
+  form,
+  onUpdate,
+}: SettingsCftoolsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>CFTools / GameLabs</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SettingsField
+          label="Server API ID"
+          value={form.cftoolsServerApiId}
+          onChange={(value) => onUpdate("cftoolsServerApiId", value)}
+        />
+        <SettingsField
+          label="Application ID"
+          value={form.cftoolsAppId}
+          onChange={(value) => onUpdate("cftoolsAppId", value)}
+        />
+        <SettingsField
+          label="Secret"
+          value={form.cftoolsSecret}
+          onChange={(value) => onUpdate("cftoolsSecret", value)}
+        />
+        <SettingsField
+          label="Enterprise Key (optional)"
+          value={form.cftoolsEnterpriseKey}
+          onChange={(value) => onUpdate("cftoolsEnterpriseKey", value)}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/components/settings/SettingsField.tsx
+++ b/client/components/settings/SettingsField.tsx
@@ -1,0 +1,21 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type SettingsFieldProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export default function SettingsField({
+  label,
+  value,
+  onChange,
+}: SettingsFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <Input value={value} onChange={(event) => onChange(event.target.value)} />
+    </div>
+  );
+}

--- a/client/components/settings/SettingsHeader.tsx
+++ b/client/components/settings/SettingsHeader.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@/components/ui/button";
+
+type SettingsHeaderProps = {
+  onSave: () => void;
+  isSaving: boolean;
+};
+
+export default function SettingsHeader({
+  onSave,
+  isSaving,
+}: SettingsHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <h2 className="text-2xl font-bold">Settings</h2>
+        <p className="text-sm text-muted-foreground">
+          All important paths/parameters are editable here.
+        </p>
+      </div>
+      <Button onClick={onSave} disabled={isSaving}>
+        Save
+      </Button>
+    </div>
+  );
+}

--- a/client/components/settings/SettingsHealthCard.tsx
+++ b/client/components/settings/SettingsHealthCard.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type HealthCheck = {
+  key: string;
+  label: string;
+  exists: boolean;
+};
+
+type SettingsHealthCardProps = {
+  checks?: HealthCheck[];
+};
+
+export default function SettingsHealthCard({
+  checks,
+}: SettingsHealthCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Health Check</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm space-y-2">
+        {checks?.map((check) => (
+          <div
+            key={check.key}
+            className="flex items-center justify-between gap-3"
+          >
+            <div className="font-medium">{check.label}</div>
+            <div
+              className={`text-xs ${
+                check.exists ? "text-status-online" : "text-status-offline"
+              }`}
+            >
+              {check.exists ? "OK" : "Missing"}
+            </div>
+          </div>
+        ))}
+        <p className="text-xs text-muted-foreground">
+          If a path is missing, fix it here. The panel is designed so you don't
+          have to manually edit config files.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/components/settings/SettingsLaunchCard.tsx
+++ b/client/components/settings/SettingsLaunchCard.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import SettingsField from "@/components/settings/SettingsField";
+import type { SettingsModel } from "@/types/settings";
+import type { UpdateSettings } from "@/components/settings/types";
+
+type SettingsLaunchCardProps = {
+  form: SettingsModel;
+  onUpdate: UpdateSettings;
+};
+
+export default function SettingsLaunchCard({
+  form,
+  onUpdate,
+}: SettingsLaunchCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Launch Parameters</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SettingsField
+          label="serverDZ.cfg"
+          value={form.serverConfigFile}
+          onChange={(value) => onUpdate("serverConfigFile", value)}
+        />
+        <SettingsField
+          label="Game Port"
+          value={String(form.serverPort)}
+          onChange={(value) => onUpdate("serverPort", Number(value))}
+        />
+        <div className="md:col-span-2">
+          <Label>Additional Launch Args</Label>
+          <Textarea
+            value={form.additionalLaunchArgs}
+            onChange={(event) =>
+              onUpdate("additionalLaunchArgs", event.target.value)
+            }
+            className="min-h-[120px] font-mono"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/components/settings/SettingsPathsCard.tsx
+++ b/client/components/settings/SettingsPathsCard.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import SettingsField from "@/components/settings/SettingsField";
+import type { SettingsModel } from "@/types/settings";
+import type { UpdateSettings } from "@/components/settings/types";
+
+type SettingsPathsCardProps = {
+  form: SettingsModel;
+  onUpdate: UpdateSettings;
+};
+
+export default function SettingsPathsCard({
+  form,
+  onUpdate,
+}: SettingsPathsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Paths (Windows/Linux)</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SettingsField
+          label="SteamCMD Path"
+          value={form.steamcmdPath}
+          onChange={(value) => onUpdate("steamcmdPath", value)}
+        />
+        <SettingsField
+          label="DayZ Server Path"
+          value={form.dayzServerPath}
+          onChange={(value) => onUpdate("dayzServerPath", value)}
+        />
+        <SettingsField
+          label="Profiles Path"
+          value={form.profilesPath}
+          onChange={(value) => onUpdate("profilesPath", value)}
+        />
+        <SettingsField
+          label="BattlEye CFG Path (file or folder)"
+          value={form.battleyeCfgPath}
+          onChange={(value) => onUpdate("battleyeCfgPath", value)}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/components/settings/SettingsRconCard.tsx
+++ b/client/components/settings/SettingsRconCard.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import SettingsField from "@/components/settings/SettingsField";
+import type { SettingsModel } from "@/types/settings";
+import type { UpdateSettings } from "@/components/settings/types";
+
+type SettingsRconCardProps = {
+  form: SettingsModel;
+  onUpdate: UpdateSettings;
+};
+
+export default function SettingsRconCard({
+  form,
+  onUpdate,
+}: SettingsRconCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>RCON (BattlEye)</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SettingsField
+          label="RCON Host"
+          value={form.rconHost}
+          onChange={(value) => onUpdate("rconHost", value)}
+        />
+        <SettingsField
+          label="RCON Port"
+          value={String(form.rconPort)}
+          onChange={(value) => onUpdate("rconPort", Number(value))}
+        />
+        <div className="space-y-2 md:col-span-2">
+          <Label>RCON Password</Label>
+          <Input
+            type="password"
+            value={form.rconPassword}
+            onChange={(event) =>
+              onUpdate("rconPassword", event.target.value)
+            }
+            placeholder="Enter BattlEye RCON password"
+          />
+          <p className="text-xs text-muted-foreground">
+            We don't read the password from BEServer_x64.cfg because that file
+            name may change after the server starts.
+          </p>
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <Label>Auto-connect RCON when server starts</Label>
+          <Input
+            value={form.rconAutoConnect ? "true" : "false"}
+            onChange={(event) =>
+              onUpdate("rconAutoConnect", event.target.value === "true")
+            }
+            placeholder="true/false"
+          />
+          <p className="text-xs text-muted-foreground">
+            Set to "true" to let the panel automatically connect after the DayZ
+            server process is started.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/components/settings/SettingsSteamCard.tsx
+++ b/client/components/settings/SettingsSteamCard.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import SettingsField from "@/components/settings/SettingsField";
+import type { SettingsModel } from "@/types/settings";
+import type { UpdateSettings } from "@/components/settings/types";
+
+type SettingsSteamCardProps = {
+  form: SettingsModel;
+  onUpdate: UpdateSettings;
+};
+
+export default function SettingsSteamCard({
+  form,
+  onUpdate,
+}: SettingsSteamCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Steam (for SteamCMD Workshop Downloads)</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SettingsField
+          label="Steam Username"
+          value={form.steamUser}
+          onChange={(value) => onUpdate("steamUser", value)}
+        />
+        <SettingsField
+          label="Steam Password"
+          value={form.steamPassword}
+          onChange={(value) => onUpdate("steamPassword", value)}
+        />
+        <p className="text-xs text-muted-foreground md:col-span-2">
+          For security, consider using a dedicated Steam account. In future
+          versions we can add encryption/Windows Credential Manager.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/components/settings/types.ts
+++ b/client/components/settings/types.ts
@@ -1,0 +1,6 @@
+import type { SettingsModel } from "@/types/settings";
+
+export type UpdateSettings = (
+  key: keyof SettingsModel,
+  value: SettingsModel[keyof SettingsModel]
+) => void;

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,187 +1,30 @@
-import { Users, Zap, Clock, Activity } from "lucide-react";
-import StatCard from "@/components/StatCard";
-import PlayerCard from "@/components/PlayerCard";
+import ActivityFeedCard from "@/components/dashboard/ActivityFeedCard";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import DashboardStatsGrid from "@/components/dashboard/DashboardStatsGrid";
+import OnlinePlayersCard from "@/components/dashboard/OnlinePlayersCard";
+import ServerControlsCard from "@/components/dashboard/ServerControlsCard";
+import {
+  onlinePlayers,
+  recentActivity,
+} from "@/components/dashboard/dashboardData";
 
 export default function Dashboard() {
-  // Mock data - in real app, this would come from an API
-  const onlinePlayers = [
-    {
-      id: "1",
-      name: "SurvivalMaster",
-      playerId: "76561198012345678",
-      playtime: "45 hrs",
-      status: "online" as const,
-      kills: 23,
-      deaths: 8,
-    },
-    {
-      id: "2",
-      name: "ZombieSH00TER",
-      playerId: "76561198087654321",
-      playtime: "32 hrs",
-      status: "online" as const,
-      kills: 15,
-      deaths: 12,
-    },
-    {
-      id: "3",
-      name: "DesperateFarmer",
-      playerId: "76561198056789012",
-      playtime: "12 hrs",
-      status: "online" as const,
-      kills: 3,
-      deaths: 5,
-    },
-  ];
-
-  const recentActivity = [
-    {
-      id: "1",
-      action: "Player joined",
-      player: "SurvivalMaster",
-      time: "5 minutes ago",
-    },
-    {
-      id: "2",
-      action: "Player left",
-      player: "NightOwl",
-      time: "12 minutes ago",
-    },
-    {
-      id: "3",
-      action: "Server restarted",
-      player: "Admin",
-      time: "2 hours ago",
-    },
-    {
-      id: "4",
-      action: "Player banned",
-      player: "RudePlayer",
-      time: "1 day ago",
-    },
-  ];
-
   return (
     <div className="p-6 lg:p-8">
-      {/* Header */}
-      <div className="mb-8">
-        <h2 className="text-3xl font-bold text-foreground mb-2">Dashboard</h2>
-        <p className="text-muted-foreground">
-          Welcome to your DayZ server management panel
-        </p>
-      </div>
+      <DashboardHeader />
+      <DashboardStatsGrid />
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <StatCard
-          label="Players Online"
-          value="3/32"
-          icon={<Users className="w-6 h-6" />}
-          trend={{ value: 15, isPositive: true }}
-          color="emerald"
-        />
-        <StatCard
-          label="Server Uptime"
-          value="12d 8h"
-          icon={<Clock className="w-6 h-6" />}
-          color="cyan"
-        />
-        <StatCard
-          label="CPU Usage"
-          value="24%"
-          icon={<Zap className="w-6 h-6" />}
-          trend={{ value: 5, isPositive: true }}
-          color="amber"
-        />
-        <StatCard
-          label="Network"
-          value="145 Mbps"
-          icon={<Activity className="w-6 h-6" />}
-          trend={{ value: 2, isPositive: false }}
-          color="cyan"
-        />
-      </div>
-
-      {/* Main Content Grid */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Online Players */}
         <div className="lg:col-span-2">
-          <div className="bg-card border border-border rounded-lg p-6">
-            <div className="flex items-center justify-between mb-6">
-              <h3 className="text-xl font-bold text-foreground">
-                Online Players
-              </h3>
-              <span className="px-3 py-1 rounded-full bg-primary/20 text-primary text-sm font-semibold">
-                {onlinePlayers.length} Active
-              </span>
-            </div>
-
-            <div className="grid grid-cols-1 gap-4">
-              {onlinePlayers.map((player) => (
-                <PlayerCard
-                  key={player.id}
-                  name={player.name}
-                  playerId={player.playerId}
-                  playtime={player.playtime}
-                  status={player.status}
-                  kills={player.kills}
-                  deaths={player.deaths}
-                />
-              ))}
-            </div>
-          </div>
+          <OnlinePlayersCard players={onlinePlayers} />
         </div>
-
-        {/* Activity Feed */}
         <div>
-          <div className="bg-card border border-border rounded-lg p-6 h-full">
-            <h3 className="text-xl font-bold text-foreground mb-6">
-              Recent Activity
-            </h3>
-
-            <div className="space-y-4">
-              {recentActivity.map((item) => (
-                <div
-                  key={item.id}
-                  className="pb-4 border-b border-border last:pb-0 last:border-0"
-                >
-                  <p className="text-sm font-medium text-foreground">
-                    {item.action}
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {item.player}
-                  </p>
-                  <p className="text-xs text-muted-foreground/60 mt-2">
-                    {item.time}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
+          <ActivityFeedCard items={recentActivity} />
         </div>
       </div>
 
-      {/* Server Controls */}
       <div className="mt-8">
-        <div className="bg-card border border-border rounded-lg p-6">
-          <h3 className="text-lg font-bold text-foreground mb-4">
-            Server Controls
-          </h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <button className="btn-primary px-4 py-3 rounded-lg font-semibold transition-all hover:shadow-lg hover:shadow-primary/20">
-              Restart Server
-            </button>
-            <button className="btn-primary px-4 py-3 rounded-lg font-semibold transition-all hover:shadow-lg hover:shadow-primary/20">
-              Save World
-            </button>
-            <button className="btn-secondary px-4 py-3 rounded-lg font-semibold">
-              Broadcast Message
-            </button>
-            <button className="btn-secondary px-4 py-3 rounded-lg font-semibold">
-              View Logs
-            </button>
-          </div>
-        </div>
+        <ServerControlsCard />
       </div>
     </div>
   );

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -1,37 +1,23 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, apiPut } from "@/lib/http";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
+import SettingsCftoolsCard from "@/components/settings/SettingsCftoolsCard";
+import SettingsHeader from "@/components/settings/SettingsHeader";
+import SettingsHealthCard from "@/components/settings/SettingsHealthCard";
+import SettingsLaunchCard from "@/components/settings/SettingsLaunchCard";
+import SettingsPathsCard from "@/components/settings/SettingsPathsCard";
+import SettingsRconCard from "@/components/settings/SettingsRconCard";
+import SettingsSteamCard from "@/components/settings/SettingsSteamCard";
 import { useToast } from "@/hooks/use-toast";
-
-type SettingsModel = {
-  steamcmdPath: string;
-  dayzServerPath: string;
-  profilesPath: string;
-  battleyeCfgPath: string;
-  rconHost: string;
-  rconPort: number;
-  rconPassword: string;
-  rconAutoConnect: boolean;
-  serverConfigFile: string;
-  serverPort: number;
-  additionalLaunchArgs: string;
-  steamUser: string;
-  steamPassword: string;
-  cftoolsServerApiId: string;
-  cftoolsAppId: string;
-  cftoolsSecret: string;
-  cftoolsEnterpriseKey: string;
-};
+import type { SettingsModel } from "@/types/settings";
 
 export default function Settings() {
   const qc = useQueryClient();
   const { toast } = useToast();
-  const q = useQuery({ queryKey: ["settings"], queryFn: () => api<SettingsModel>("/settings") });
+  const q = useQuery({
+    queryKey: ["settings"],
+    queryFn: () => api<SettingsModel>("/settings"),
+  });
   const [form, setForm] = useState<SettingsModel | null>(null);
 
   useEffect(() => {
@@ -45,14 +31,19 @@ export default function Settings() {
       qc.invalidateQueries({ queryKey: ["config-files"] });
       toast({ title: "Settings saved" });
     },
-    onError: (e: any) => toast({ title: "Save failed", description: `${e.code ?? ""} ${e.message}` }),
+    onError: (e: any) =>
+      toast({ title: "Save failed", description: `${e.code ?? ""} ${e.message}` }),
   });
 
-  const health = useQuery({ queryKey: ["settings-health"], queryFn: () => api<any>("/settings/health"), enabled: !!form });
+  const health = useQuery({
+    queryKey: ["settings-health"],
+    queryFn: () => api<any>("/settings/health"),
+    enabled: !!form,
+  });
 
-  const update = (k: keyof SettingsModel, v: any) => {
+  const update = (key: keyof SettingsModel, value: SettingsModel[keyof SettingsModel]) => {
     if (!form) return;
-    setForm({ ...form, [k]: v });
+    setForm({ ...form, [key]: value });
   };
 
   if (!form) {
@@ -61,144 +52,13 @@ export default function Settings() {
 
   return (
     <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold">Settings</h2>
-          <p className="text-sm text-muted-foreground">All important paths/parameters are editable here.</p>
-        </div>
-        <Button onClick={() => save.mutate()} disabled={save.isPending}>
-          Save
-        </Button>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Health Check</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm space-y-2">
-          {health.data?.checks?.map((c: any) => (
-            <div key={c.key} className="flex items-center justify-between gap-3">
-              <div className="font-medium">{c.label}</div>
-              <div className={`text-xs ${c.exists ? "text-status-online" : "text-status-offline"}`}>
-                {c.exists ? "OK" : "Missing"}
-              </div>
-            </div>
-          ))}
-          <p className="text-xs text-muted-foreground">
-            If a path is missing, fix it here. The panel is designed so you don't have to manually edit config files.
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Paths (Windows/Linux)</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Field label="SteamCMD Path" value={form.steamcmdPath} onChange={(v) => update("steamcmdPath", v)} />
-          <Field label="DayZ Server Path" value={form.dayzServerPath} onChange={(v) => update("dayzServerPath", v)} />
-          <Field label="Profiles Path" value={form.profilesPath} onChange={(v) => update("profilesPath", v)} />
-          <Field
-            label="BattlEye CFG Path (file or folder)"
-            value={form.battleyeCfgPath}
-            onChange={(v) => update("battleyeCfgPath", v)}
-          />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>RCON (BattlEye)</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Field label="RCON Host" value={form.rconHost} onChange={(v) => update("rconHost", v)} />
-          <Field label="RCON Port" value={String(form.rconPort)} onChange={(v) => update("rconPort", Number(v))} />
-          <div className="space-y-2 md:col-span-2">
-            <Label>RCON Password</Label>
-            <Input
-              type="password"
-              value={form.rconPassword}
-              onChange={(e) => update("rconPassword", e.target.value)}
-              placeholder="Enter BattlEye RCON password"
-            />
-            <p className="text-xs text-muted-foreground">
-              We don't read the password from BEServer_x64.cfg because that file name may change after the server starts.
-            </p>
-          </div>
-          <div className="space-y-2 md:col-span-2">
-            <Label>Auto-connect RCON when server starts</Label>
-            <Input
-              value={form.rconAutoConnect ? "true" : "false"}
-              onChange={(e) => update("rconAutoConnect", e.target.value === "true")}
-              placeholder="true/false"
-            />
-            <p className="text-xs text-muted-foreground">
-              Set to "true" to let the panel automatically connect after the DayZ server process is started.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Launch Parameters</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Field label="serverDZ.cfg" value={form.serverConfigFile} onChange={(v) => update("serverConfigFile", v)} />
-          <Field label="Game Port" value={String(form.serverPort)} onChange={(v) => update("serverPort", Number(v))} />
-          <div className="md:col-span-2">
-            <Label>Additional Launch Args</Label>
-            <Textarea
-              value={form.additionalLaunchArgs}
-              onChange={(e) => update("additionalLaunchArgs", e.target.value)}
-              className="min-h-[120px] font-mono"
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Steam (for SteamCMD Workshop Downloads)</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Field label="Steam Username" value={form.steamUser} onChange={(v) => update("steamUser", v)} />
-          <Field label="Steam Password" value={form.steamPassword} onChange={(v) => update("steamPassword", v)} />
-          <p className="text-xs text-muted-foreground md:col-span-2">
-            For security, consider using a dedicated Steam account. In future versions we can add encryption/Windows
-            Credential Manager.
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>CFTools / GameLabs</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Field label="Server API ID" value={form.cftoolsServerApiId} onChange={(v) => update("cftoolsServerApiId", v)} />
-          <Field label="Application ID" value={form.cftoolsAppId} onChange={(v) => update("cftoolsAppId", v)} />
-          <Field label="Secret" value={form.cftoolsSecret} onChange={(v) => update("cftoolsSecret", v)} />
-          <Field label="Enterprise Key (optional)" value={form.cftoolsEnterpriseKey} onChange={(v) => update("cftoolsEnterpriseKey", v)} />
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  value,
-  onChange,
-}: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <div className="space-y-2">
-      <Label>{label}</Label>
-      <Input value={value} onChange={(e) => onChange(e.target.value)} />
+      <SettingsHeader onSave={() => save.mutate()} isSaving={save.isPending} />
+      <SettingsHealthCard checks={health.data?.checks} />
+      <SettingsPathsCard form={form} onUpdate={update} />
+      <SettingsRconCard form={form} onUpdate={update} />
+      <SettingsLaunchCard form={form} onUpdate={update} />
+      <SettingsSteamCard form={form} onUpdate={update} />
+      <SettingsCftoolsCard form={form} onUpdate={update} />
     </div>
   );
 }

--- a/client/types/settings.ts
+++ b/client/types/settings.ts
@@ -1,0 +1,19 @@
+export type SettingsModel = {
+  steamcmdPath: string;
+  dayzServerPath: string;
+  profilesPath: string;
+  battleyeCfgPath: string;
+  rconHost: string;
+  rconPort: number;
+  rconPassword: string;
+  rconAutoConnect: boolean;
+  serverConfigFile: string;
+  serverPort: number;
+  additionalLaunchArgs: string;
+  steamUser: string;
+  steamPassword: string;
+  cftoolsServerApiId: string;
+  cftoolsAppId: string;
+  cftoolsSecret: string;
+  cftoolsEnterpriseKey: string;
+};


### PR DESCRIPTION
### Motivation
- Break up large, monolithic page files into focused, reusable components to improve readability and maintainability.
- Move mock/dashboard data and shared shapes into dedicated modules so they can be reused and tested independently.
- Extract the settings model to a central type to avoid duplicated type definitions and make future API/type changes easier.

### Description
- Split the dashboard into smaller components and data files: `client/components/dashboard/DashboardHeader.tsx`, `DashboardStatsGrid.tsx`, `OnlinePlayersCard.tsx`, `ActivityFeedCard.tsx`, `ServerControlsCard.tsx`, and `dashboardData.ts`, and updated `client/pages/Dashboard.tsx` to compose those components and import `onlinePlayers`/`recentActivity`.
- Modularized the settings page into card/field components under `client/components/settings/` including `SettingsField.tsx`, `SettingsHeader.tsx`, `SettingsHealthCard.tsx`, `SettingsPathsCard.tsx`, `SettingsRconCard.tsx`, `SettingsLaunchCard.tsx`, `SettingsSteamCard.tsx`, `SettingsCftoolsCard.tsx`, and helper `types.ts` for the update callback.
- Extracted the settings model type to `client/types/settings.ts` and updated `client/pages/Settings.tsx` to import and use the shared `SettingsModel`, simplified the `update` function signature, and replaced inline UI blocks with the new components.
- Minor cleanup: removed inline mock data from `Dashboard.tsx`, replaced duplicated JSX with component imports, and kept existing API calls/React Query logic in `Settings.tsx` intact.

### Testing
- No automated tests were executed as part of this change (no `pnpm test`/`vitest` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e44858560832f89270c167c051b95)