### PR TITLE
Fix Vitest configuration to avoid loading Prisma during tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:push": "prisma db push",
     "db:setup": "npm run db:generate && npm run db:push",
     "doctor": "tsx scripts/doctor.ts",
-    "test": "vitest --run",
+    "test": "vitest --run --mode test",
     "format.fix": "prettier --write .",
     "typecheck": "tsc"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,38 +1,51 @@
 import { defineConfig, Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { createServer } from "./server";
 import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    fs: {
-      allow: ["./client", "./shared"],
-      deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+export default defineConfig(({ mode }) => {
+  const plugins = [react()];
+  const isVitest = !!process.env.VITEST;
+
+  if (mode === "development" && !isVitest) {
+    plugins.push(expressPlugin());
+  }
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      fs: {
+        allow: ["./client", "./shared"],
+        deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+      },
     },
-  },
-  build: {
-    outDir: "dist/spa",
-  },
-  plugins: [react(), expressPlugin()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./client"),
-      "@shared": path.resolve(__dirname, "./shared"),
+    build: {
+      outDir: "dist/spa",
     },
-  },
-}));
+    plugins,
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./client"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
+    },
+  };
+});
 
 function expressPlugin(): Plugin {
   return {
     name: "express-plugin",
     apply: "serve", // Only apply during development (serve mode)
-    configureServer(server) {
+    async configureServer(server) {
+      if (server.config.mode === "test") {
+        return;
+      }
+
+      const { createServer } = await import("./server");
       const app = createServer();
 
       // Add Express app as middleware to Vite dev server

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./client"),
+      "@shared": path.resolve(__dirname, "./shared"),
+    },
+  },
+});


### PR DESCRIPTION
### Motivation
- Tests were failing because the Vite dev-server plugin attempted to load the Express app (which initializes Prisma) during Vitest runs, causing a `@prisma/client` module error. 
- The goal is to decouple unit tests from runtime server initialization so tests can run in CI/workspaces without hitting Prisma engine resolution.

### Description
- Add `vitest.config.ts` to provide a dedicated Vitest config with `node` environment and shared path aliases for `@` and `@shared`.
- Update `vite.config.ts` to only include the Express dev-server plugin in development mode, to dynamically import the server at runtime, and to early-return from the plugin when Vite is running in test mode (`server.config.mode === "test"`).
- Change the test script in `package.json` to run Vitest in explicit test mode with `vitest --run --mode test` so the Vite config can detect and skip server wiring.

### Testing
- Running `pnpm test` initially failed with a Prisma module load error before the changes were applied. 
- After the config changes, `pnpm test` succeeded: all test files passed (`client/lib/utils.spec.ts` — 5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e4915b0c8832fade744e141fdf066)