### PR TITLE
Add live Server Monitor panel and avoid loading Express during Vitest runs

### DIFF
--- a/client/pages/Server.tsx
+++ b/client/pages/Server.tsx
@@ -3,6 +3,7 @@ import { api, apiPost } from "@/lib/http";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
 
 type ServerStatus = {
   running: boolean;
@@ -11,9 +12,15 @@ type ServerStatus = {
   lastExit: { code: number | null; signal: string | null } | null;
 };
 
+type TailResp = {
+  file: string;
+  lines: string[];
+};
+
 export default function Server() {
   const qc = useQueryClient();
   const { toast } = useToast();
+  const logFile = "dayz-server-current.log";
 
   const status = useQuery({
     queryKey: ["server-status"],
@@ -49,6 +56,12 @@ export default function Server() {
   });
 
   const s = status.data;
+  const logTail = useQuery({
+    queryKey: ["logs-tail", logFile],
+    queryFn: () => api<TailResp>(`/logs/tail?file=${encodeURIComponent(logFile)}&lines=200`),
+    refetchInterval: 2000,
+    retry: false,
+  });
 
   return (
     <div className="p-6 space-y-6">
@@ -96,6 +109,28 @@ export default function Server() {
             Note: v0.1 uses a simple process supervisor. For production usage you can later run this panel as a Windows
             service and let it manage DayZ with scheduled restarts and health checks.
           </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Server Monitor</CardTitle>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span
+              className={cn("h-2 w-2 rounded-full", s?.running ? "bg-emerald-500" : "bg-muted-foreground/40")}
+            />
+            <span>{s?.running ? "Live" : "Offline"}</span>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="text-xs text-muted-foreground">
+            {logFile} • auto-refreshing every 2s
+          </div>
+          <pre className="text-xs bg-black/70 text-white rounded-lg p-4 overflow-auto max-h-[320px]">
+            {logTail.isError
+              ? "Log file not found yet. Start the server to begin streaming output."
+              : (logTail.data?.lines ?? []).join("\n")}
+          </pre>
         </CardContent>
       </Card>
     </div>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:push": "prisma db push",
     "db:setup": "npm run db:generate && npm run db:push",
     "doctor": "tsx scripts/doctor.ts",
-    "test": "vitest --run",
+    "test": "vitest --run --mode test",
     "format.fix": "prettier --write .",
     "typecheck": "tsc"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,38 +1,51 @@
 import { defineConfig, Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { createServer } from "./server";
 import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    fs: {
-      allow: ["./client", "./shared"],
-      deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+export default defineConfig(({ mode }) => {
+  const plugins = [react()];
+  const isVitest = !!process.env.VITEST;
+
+  if (mode === "development" && !isVitest) {
+    plugins.push(expressPlugin());
+  }
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      fs: {
+        allow: ["./client", "./shared"],
+        deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+      },
     },
-  },
-  build: {
-    outDir: "dist/spa",
-  },
-  plugins: [react(), expressPlugin()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./client"),
-      "@shared": path.resolve(__dirname, "./shared"),
+    build: {
+      outDir: "dist/spa",
     },
-  },
-}));
+    plugins,
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./client"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
+    },
+  };
+});
 
 function expressPlugin(): Plugin {
   return {
     name: "express-plugin",
     apply: "serve", // Only apply during development (serve mode)
-    configureServer(server) {
+    async configureServer(server) {
+      if (server.config.mode === "test") {
+        return;
+      }
+
+      const { createServer } = await import("./server");
       const app = createServer();
 
       // Add Express app as middleware to Vite dev server

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./client"),
+      "@shared": path.resolve(__dirname, "./shared"),
+    },
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a quick in-panel monitor to stream DayZ server stdout/stderr so operators can see live server output without leaving the UI. 
- Prevent test runs from loading the Express app (which initializes Prisma) so Vitest can run in CI/workspaces without Prisma client resolution errors.

### Description
- Add a Server Monitor to `client/pages/Server.tsx` that tails `data/logs/dayz-server-current.log` via the existing `/logs/tail` endpoint, shows a live/offline indicator and handles missing logs; introduced `TailResp` type and uses `cn` from `@/lib/utils`.
- Update `vite.config.ts` to only register the Express dev-server plugin in development and dynamically `import("./server")`, and early-return from the plugin when Vite is running in test mode (`server.config.mode === "test"`).
- Add `vitest.config.ts` with `test.environment: "node"` and shared path aliases for `@` and `@shared` so tests run in a node-like environment.
- Change the test script in `package.json` to run Vitest in explicit test mode with `vitest --run --mode test` so the Vite config can detect and skip server wiring.

### Testing
- Attempted to start the dev server in test mode with `pnpm dev -- --mode test --host 0.0.0.0 --port 4173`, which failed because the Prisma client engine (`@prisma/client`) was not available, producing a module resolution error; this prevented a full dev-server preview.
- No unit tests were executed as part of this change set; previous Vitest configuration work (in an earlier change) is intended to allow `pnpm test` to run in CI without loading the server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e4915b0c8832fade744e141fdf066)