### PR TITLE
Style Server Monitor like DayZ console and make dev-server test-friendly

### DIFF
--- a/client/pages/Server.tsx
+++ b/client/pages/Server.tsx
@@ -3,6 +3,7 @@ import { api, apiPost } from "@/lib/http";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
 
 type ServerStatus = {
   running: boolean;
@@ -11,9 +12,15 @@ type ServerStatus = {
   lastExit: { code: number | null; signal: string | null } | null;
 };
 
+type TailResp = {
+  file: string;
+  lines: string[];
+};
+
 export default function Server() {
   const qc = useQueryClient();
   const { toast } = useToast();
+  const logFile = "dayz-server-current.log";
 
   const status = useQuery({
     queryKey: ["server-status"],
@@ -49,6 +56,12 @@ export default function Server() {
   });
 
   const s = status.data;
+  const logTail = useQuery({
+    queryKey: ["logs-tail", logFile],
+    queryFn: () => api<TailResp>(`/logs/tail?file=${encodeURIComponent(logFile)}&lines=200`),
+    refetchInterval: 2000,
+    retry: false,
+  });
 
   return (
     <div className="p-6 space-y-6">
@@ -96,6 +109,38 @@ export default function Server() {
             Note: v0.1 uses a simple process supervisor. For production usage you can later run this panel as a Windows
             service and let it manage DayZ with scheduled restarts and health checks.
           </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Server Monitor</CardTitle>
+            <div className="text-xs text-muted-foreground">{logFile} • auto-refreshing every 2s</div>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span
+              className={cn("h-2 w-2 rounded-full", s?.running ? "bg-emerald-500" : "bg-muted-foreground/40")}
+            />
+            <span>{s?.running ? "Live" : "Offline"}</span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="border border-muted/50 rounded-lg bg-white">
+            <div className="flex items-center justify-between border-b border-muted/50 bg-muted/20 px-3 py-1 text-xs">
+              <div className="font-medium text-muted-foreground">
+                DayZ Console (RPT): {s?.running ? "running" : "stopped"}
+              </div>
+              <div className="text-muted-foreground">
+                {s?.pid ? `PID ${s.pid}` : "PID -"}
+              </div>
+            </div>
+            <pre className="text-[11px] leading-relaxed font-mono bg-black text-emerald-200 p-4 overflow-auto min-h-[360px] max-h-[520px]">
+              {logTail.isError
+                ? "Log file not found yet. Start the server to begin streaming output."
+                : (logTail.data?.lines ?? []).join("\n")}
+            </pre>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:push": "prisma db push",
     "db:setup": "npm run db:generate && npm run db:push",
     "doctor": "tsx scripts/doctor.ts",
-    "test": "vitest --run",
+    "test": "vitest --run --mode test",
     "format.fix": "prettier --write .",
     "typecheck": "tsc"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,38 +1,51 @@
 import { defineConfig, Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { createServer } from "./server";
 import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    fs: {
-      allow: ["./client", "./shared"],
-      deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+export default defineConfig(({ mode }) => {
+  const plugins = [react()];
+  const isVitest = !!process.env.VITEST;
+
+  if (mode === "development" && !isVitest) {
+    plugins.push(expressPlugin());
+  }
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      fs: {
+        allow: ["./client", "./shared"],
+        deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+      },
     },
-  },
-  build: {
-    outDir: "dist/spa",
-  },
-  plugins: [react(), expressPlugin()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./client"),
-      "@shared": path.resolve(__dirname, "./shared"),
+    build: {
+      outDir: "dist/spa",
     },
-  },
-}));
+    plugins,
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./client"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
+    },
+  };
+});
 
 function expressPlugin(): Plugin {
   return {
     name: "express-plugin",
     apply: "serve", // Only apply during development (serve mode)
-    configureServer(server) {
+    async configureServer(server) {
+      if (server.config.mode === "test") {
+        return;
+      }
+
+      const { createServer } = await import("./server");
       const app = createServer();
 
       // Add Express app as middleware to Vite dev server

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./client"),
+      "@shared": path.resolve(__dirname, "./shared"),
+    },
+  },
+});


### PR DESCRIPTION
### Motivation
- Present the Server Monitor as a DayZ-style console window so operators can view server RPT output in the UI consistent with the provided screenshot.  
- Avoid wiring the Express dev server when running tests so test runs do not initialize Prisma or other server-only dependencies.

### Description
- Restyled the Server Monitor in `client/pages/Server.tsx` to a window-like header with status/PID display and a terminal-styled `pre` output pane, added the `TailResp` type, the `cn` import, and a `logTail` query to tail `dayz-server-current.log`.  
- Updated `vite.config.ts` to register the Express dev-server plugin only in development and to dynamically import `./server`, and added an early return when Vite is running in test mode to prevent server wiring.  
- Added `vitest.config.ts` with `test.environment: "node"` and path aliases for `@` and `@shared`, and changed the `test` script in `package.json` to `vitest --run --mode test` so test mode can be detected.

### Testing
- No automated unit tests were executed for this UI-focused change.  
- The change to the `test` script and Vite plugin early-return were added so tests can run without loading Express/Prisma, but end-to-end verification was not run in this environment because the dev server could not be started due to missing Prisma client binaries.  
- UI change validated by code review and local file updates only (visual verification requires running the dev server in an environment with Prisma available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e4915b0c8832fade744e141fdf066)