### PR TITLE
Add latest RPT log tailing for server monitor

### DIFF
--- a/client/pages/Server.tsx
+++ b/client/pages/Server.tsx
@@ -20,8 +20,6 @@ type TailResp = {
 export default function Server() {
   const qc = useQueryClient();
   const { toast } = useToast();
-  const logFile = "dayz-server-current.log";
-
   const status = useQuery({
     queryKey: ["server-status"],
     queryFn: () => api<ServerStatus>("/server/status"),
@@ -57,8 +55,8 @@ export default function Server() {
 
   const s = status.data;
   const logTail = useQuery({
-    queryKey: ["logs-tail", logFile],
-    queryFn: () => api<TailResp>(`/logs/tail?file=${encodeURIComponent(logFile)}&lines=200`),
+    queryKey: ["logs-rpt-latest"],
+    queryFn: () => api<TailResp>("/logs/rpt/latest?lines=200"),
     refetchInterval: 2000,
     retry: false,
   });
@@ -124,11 +122,11 @@ export default function Server() {
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="text-xs text-muted-foreground">
-            {logFile} • auto-refreshing every 2s
+            {logTail.data?.file ?? "DayZServer_x64*.RPT"} • auto-refreshing every 2s
           </div>
           <pre className="text-xs bg-black/70 text-white rounded-lg p-4 overflow-auto max-h-[320px]">
             {logTail.isError
-              ? "Log file not found yet. Start the server to begin streaming output."
+              ? "Latest RPT log not found yet. Start the server to generate a new report file."
               : (logTail.data?.lines ?? []).join("\n")}
           </pre>
         </CardContent>


### PR DESCRIPTION
### Motivation
- Support showing the most-recent DayZ server RPT (report) file from the configured Profiles Path because the server creates a new `DayZServer_x64***.rpt` file on each start and the monitor should always display the current file tail.

### Description
- Add a new API endpoint `GET /api/logs/rpt/latest` that reads the configured `profilesPath`, finds `DayZServer_x64*.RPT` files, picks the newest by modification time and returns a tailed response with `file`, `mtimeMs`, `profilesPath` and `lines` (implemented in `server/modules/logs/logs.routes.ts`).
- The endpoint uses `SettingsService` (via `getPrisma()`) to obtain the configured `profilesPath` and validates/handles no-file and IO errors with `AppError`/`ErrorCodes`.
- Update the Server Monitor UI to consume the new endpoint (`/logs/rpt/latest?lines=200`) and display the active report file name and an improved empty-state message (changes in `client/pages/Server.tsx`).

### Testing
- Attempted to run the dev server with `pnpm dev`, but startup failed due to a missing Prisma client (`.prisma/client/default`), so the new endpoint and UI were not exercised in a running environment.
- No other automated tests were run in this environment due to the same Prisma client issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e70fddfa0832fa052e38198b0fca5)