### PR TITLE
Set default DayZ launch args and add UI hint in Settings

### DIFF
--- a/client/components/settings/SettingsLaunchCard.tsx
+++ b/client/components/settings/SettingsLaunchCard.tsx
@@ -37,8 +37,12 @@ export default function SettingsLaunchCard({
             onChange={(event) =>
               onUpdate("additionalLaunchArgs", event.target.value)
             }
+            placeholder="dologs -adminlog -netlog -freezecheck"
             className="min-h-[120px] font-mono"
           />
+          <p className="text-xs text-muted-foreground">
+            Default recommended flags: dologs -adminlog -netlog -freezecheck
+          </p>
         </div>
       </CardContent>
     </Card>

--- a/server/modules/settings/settings.service.ts
+++ b/server/modules/settings/settings.service.ts
@@ -62,7 +62,10 @@ export const instanceSettingsSchema = z.object({
   // Launch params (stored as key/value and compiled into CLI args)
   serverPort: z.coerce.number().int().positive().default(2302),
   serverConfigFile: z.string().min(1).default("serverDZ.cfg"),
-  additionalLaunchArgs: z.string().optional().default(""),
+  additionalLaunchArgs: z
+    .string()
+    .optional()
+    .default("dologs -adminlog -netlog -freezecheck"),
 
   // Steam login (optional; workshop downloads often require an account)
   steamUser: z.string().optional().default("") ,


### PR DESCRIPTION
### Motivation

- Provide sensible default server launch flags so DayZ servers start with recommended logging and checks enabled.
- Surface the default flags in the Web UI so operators know which additional launch args are recommended.

### Description

- Set the default value of `additionalLaunchArgs` in the settings schema to `"dologs -adminlog -netlog -freezecheck"` in `server/modules/settings/settings.service.ts` so new/empty settings will include these flags by default.
- Add a `placeholder` and a small helper text line to the Additional Launch Args `Textarea` in `client/components/settings/SettingsLaunchCard.tsx` to show the recommended flags in the settings UI while keeping the field editable.

### Testing

- Ran the development server with `pnpm dev`, which failed to start due to a missing Prisma client module (`.prisma/client/default`), so the UI changes could not be verified via a running dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e754a0bf0832f84c6829e24cb2b70)