### PR TITLE
Remove RCON/GameLabs settings and UI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ Backend modüler tasarlandı:
 - `server/modules/config` → DayZ/BattlEye config okuma-yazma
 - `server/modules/mods` → Workshop mod DB + SteamCMD download + enable/disable
 - `server/modules/server-control` → DayZ process start/stop + junction link
-- `server/modules/rcon` → BattlEye RCON bağlantısı
-- `server/modules/cftools` → CFTools/GameLabs Data API entegrasyonu (temel)
 - `server/modules/logs` → log list/tail
 
 Her modül:

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, apiPut } from "@/lib/http";
-import SettingsCftoolsCard from "@/components/settings/SettingsCftoolsCard";
 import SettingsHeader from "@/components/settings/SettingsHeader";
 import SettingsHealthCard from "@/components/settings/SettingsHealthCard";
 import SettingsInstanceCard from "@/components/settings/SettingsInstanceCard";
 import SettingsLaunchCard from "@/components/settings/SettingsLaunchCard";
 import SettingsPathsCard from "@/components/settings/SettingsPathsCard";
-import SettingsRconCard from "@/components/settings/SettingsRconCard";
 import SettingsSteamCard from "@/components/settings/SettingsSteamCard";
 import { useToast } from "@/hooks/use-toast";
 import type { SettingsModel } from "@/types/settings";
@@ -57,10 +55,8 @@ export default function Settings() {
       <SettingsHealthCard checks={health.data?.checks} />
       <SettingsInstanceCard form={form} onUpdate={update} />
       <SettingsPathsCard form={form} onUpdate={update} />
-      <SettingsRconCard form={form} onUpdate={update} />
       <SettingsLaunchCard form={form} onUpdate={update} />
       <SettingsSteamCard form={form} onUpdate={update} />
-      <SettingsCftoolsCard form={form} onUpdate={update} />
     </div>
   );
 }

--- a/client/types/settings.ts
+++ b/client/types/settings.ts
@@ -4,17 +4,9 @@ export type SettingsModel = {
   dayzServerPath: string;
   profilesPath: string;
   battleyeCfgPath: string;
-  rconHost: string;
-  rconPort: number;
-  rconPassword: string;
-  rconAutoConnect: boolean;
   serverConfigFile: string;
   serverPort: number;
   additionalLaunchArgs: string;
   steamUser: string;
   steamPassword: string;
-  cftoolsServerApiId: string;
-  cftoolsAppId: string;
-  cftoolsSecret: string;
-  cftoolsEnterpriseKey: string;
 };

--- a/docs/SPRINT2_ISSUES.md
+++ b/docs/SPRINT2_ISSUES.md
@@ -2,7 +2,7 @@
 
 Milestone: **Sprint-2**
 
-Labels: **steamcmd**, **mods**, **rcon**, **cftools**, **ui**, **infra**, **bug**
+Labels: **steamcmd**, **mods**, **ui**, **infra**, **bug**
 
 > Not: Sprint-2 icin sadece is parcasi (issue) planidir. Kod degisikligi yok.
 
@@ -20,49 +20,28 @@ Labels: **steamcmd**, **mods**, **rcon**, **cftools**, **ui**, **infra**, **bug*
    - Label: mods, ui
    - Kapsam: -mod/-serverMod ayrimi, drag-drop siralama, preset profilleri.
 
-## RCON
-5. **Player manager**
-   - Label: rcon, ui
-   - Kapsam: player list, kick/ban/unban, whisper/global message, macros.
-6. **Scheduler**
-   - Label: rcon, infra
-   - Kapsam: zamanli mesaj/restart/wipe day otomasyonu.
-7. **Adapter secimi**
-   - Label: rcon, infra
-   - Kapsam: alternatif adapter, runtime secim ayari.
-
 ## Config Yonetimi
-8. **serverDZ.cfg editor**
+5. **serverDZ.cfg editor**
    - Label: ui, infra
    - Kapsam: parse + edit + save, validation, diff gorunumu.
-9. **Profil/instance config**
+6. **Profil/instance config**
    - Label: infra
    - Kapsam: instance config sync, clone/export/import.
 
-## GameLabs / CFTools
-10. **Token validity + rate limit + cache**
-    - Label: cftools, infra
-11. **Status/players/queue endpoints**
-    - Label: cftools, ui
-12. **Event/killfeed stream**
-    - Label: cftools, ui
-13. **Bans/whitelist management**
-    - Label: cftools
-
 ## UX / UI
-14. **Dashboard health cards**
+7. **Dashboard health cards**
     - Label: ui
-15. **Log viewer filtre/search/export**
+8. **Log viewer filtre/search/export**
     - Label: ui
-16. **Notification system**
+9. **Notification system**
     - Label: ui
-17. **Role-based auth (opsiyonel)**
+10. **Role-based auth (opsiyonel)**
     - Label: ui, infra
 
 ## Dev / Ops
-18. **CI: build + lint + unit tests**
+11. **CI: build + lint + unit tests**
     - Label: infra
-19. **E2E smoke test (/health)**
+12. **E2E smoke test (/health)**
     - Label: infra
-20. **Issue template + PR checklist**
+13. **Issue template + PR checklist**
     - Label: infra

--- a/server/modules/settings/settings.service.ts
+++ b/server/modules/settings/settings.service.ts
@@ -69,15 +69,6 @@ export const instanceSettingsSchema = z.object({
   profilesPath: z.string().min(1).default(defaultPaths.profilesPath),
   battleyeCfgPath: z.string().min(1).default(defaultPaths.battleyeCfgPath),
 
-  // RCON (BattlEye)
-  // NOTE:
-  // - Do NOT rely on BEServer_x64.cfg, because DayZ/BattlEye may rename it after the server starts.
-  // - These are entered via the Web UI so the panel can connect reliably.
-  rconHost: z.string().min(1).default("127.0.0.1"),
-  rconPort: z.coerce.number().int().positive().default(2306),
-  rconPassword: z.string().optional().default(""),
-  rconAutoConnect: z.coerce.boolean().default(true),
-
   // Launch params (stored as key/value and compiled into CLI args)
   serverPort: z.coerce.number().int().positive().default(2302),
   serverConfigFile: z.string().min(1).default("serverDZ.cfg"),
@@ -87,14 +78,8 @@ export const instanceSettingsSchema = z.object({
     .default("dologs -adminlog -netlog -freezecheck"),
 
   // Steam login (optional; workshop downloads often require an account)
-  steamUser: z.string().optional().default("") ,
-  steamPassword: z.string().optional().default("") ,
-
-  // CFTools Cloud (Data API)
-  cftoolsServerApiId: z.string().optional().default(""),
-  cftoolsAppId: z.string().optional().default(""),
-  cftoolsSecret: z.string().optional().default(""),
-  cftoolsEnterpriseKey: z.string().optional().default(""),
+  steamUser: z.string().optional().default(""),
+  steamPassword: z.string().optional().default(""),
 });
 
 export type InstanceSettings = z.infer<typeof instanceSettingsSchema>;


### PR DESCRIPTION
### Motivation
- The Settings UI referenced missing components and server code relied on RCON/GameLabs integrations that are not present, causing build errors (missing `SettingsCftoolsCard` import during client build). 
- Remove unused RCON/CFTools fields so the settings schema and client types match the current UI and avoid runtime/import problems. 
- Simplify server control logic to remove runtime RCON dependencies and reduce surface area for failures.

### Description
- Removed RCON and CFTools/GameLabs fields from the settings Zod schema in `server/modules/settings/settings.service.ts`. 
- Removed corresponding fields from the client settings type in `client/types/settings.ts`. 
- Removed `SettingsRconCard` and `SettingsCftoolsCard` imports/usages from `client/pages/Settings.tsx` to fix missing import errors. 
- Removed `RconService` usage and all RCON auto-connect and shutdown logic from `server/modules/server-control/serverControl.service.ts`, and simplified `stop()` to directly kill the process; also removed logger usage tied to that flow. 
- Updated documentation to remove RCON/CFTools references (`README.md`, `docs/SPRINT2_ISSUES.md`).

### Testing
- Attempted to run the dev server with `pnpm dev -- --host 0.0.0.0 --port 8080`, which failed due to a missing Prisma client error: `Cannot find module '.prisma/client/default'`, so the dev server did not start. 
- No automated unit tests or builds were fully executed due to the above runtime dependency error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69706bf593f0832fad5c4256fba0a35d)